### PR TITLE
Allow custom strong parameters names

### DIFF
--- a/lib/composite_content/model/blockable.rb
+++ b/lib/composite_content/model/blockable.rb
@@ -16,6 +16,12 @@ module CompositeContent
       def block_type
         self.class.name.demodulize.underscore
       end
+
+      module ClassMethods
+        def strong_parameters_names
+          column_names.collect(&:to_sym) - %i[created_at updated_at]
+        end
+      end
     end
   end
 end

--- a/lib/composite_content/slot.rb
+++ b/lib/composite_content/slot.rb
@@ -32,23 +32,26 @@ module CompositeContent
       end
 
       def strong_parameters
-        [:id, { blocks_attributes: block_column_names + [{ blockable_attributes: blockable_column_names }, :_destroy] }]
+        [
+          :id,
+          { blocks_attributes: block_strong_parameters_names + [
+            { blockable_attributes: blockable_strong_parameters_names },
+            :_destroy]
+          }
+        ]
       end
 
       protected
 
-      def block_column_names
-        @block_column_names ||= begin
-          columns = block_class.column_names.collect(&:to_sym)
-          columns - %i[slot_id blockable_id created_at updated_at]
+      def block_strong_parameters_names
+        @block_strong_parameters_names ||= begin
+          parameters = block_class.column_names.collect(&:to_sym)
+          parameters - %i[slot_id blockable_id created_at updated_at]
         end
       end
 
-      def blockable_column_names
-        @blockable_column_names ||= begin
-          columns = blockable_classes.collect(&:column_names).flatten.collect(&:to_sym).compact.uniq
-          columns - %i[created_at updated_at]
-        end
+      def blockable_strong_parameters_names
+        @blockable_strong_parameters_names ||= blockable_classes.collect(&:strong_parameters_names).flatten.compact.uniq
       end
     end
   end


### PR DESCRIPTION
Delegates strong parameters list construction to a class method on each blockable type so it can be redefined for custom block types. Fix #9 