### PR TITLE
Fix code scanning alert no. 1: CSRF protection not enabled

### DIFF
--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
 end


### PR DESCRIPTION
Fixes [https://github.com/notus-sh/composite_content/security/code-scanning/1](https://github.com/notus-sh/composite_content/security/code-scanning/1)

To fix the CSRF vulnerability, we need to enable CSRF protection in the `ApplicationController` class. This can be done by adding a call to `protect_from_forgery` with the `:exception` strategy, which raises an exception if an invalid CSRF token is provided. This ensures that any request without a valid CSRF token will be rejected, thereby protecting the application from CSRF attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
